### PR TITLE
Incorrect button type used - "cancel" instead of "reset"

### DIFF
--- a/flask_application_part/accuconf/proposals/templates/register.html
+++ b/flask_application_part/accuconf/proposals/templates/register.html
@@ -94,7 +94,7 @@
             </div>
             <div class="form-group">
                 <button type="submit" id="submit"  class="btn btn-primary" onsubmit="javascript:registerUser();">Register</button>
-                <button type="cancel" class="btn btn-default">Cancel</button>
+                <button type="reset" class="btn btn-default">Cancel</button>
             </div>
         </form>
     </div>


### PR DESCRIPTION
Clicking either of the buttons on the registration page resulted in
the user getting registered. This was due to the incorrect type used
for the cancel button.