### PR TITLE
Fixes typos replacing 'Fist' with 'First'

### DIFF
--- a/flask_application_part/accuconf/proposals/templates/review_proposal.html
+++ b/flask_application_part/accuconf/proposals/templates/review_proposal.html
@@ -56,7 +56,7 @@
                         <tr>
                             <th> Lead </th>
                             <th> Email </th>
-                            <th> Fist Name </th>
+                            <th> First Name </th>
                             <th> Last Name </th>
                             <th> Country </th>
                             <th> State </th>

--- a/flask_application_part/accuconf/proposals/templates/submit_proposal.html
+++ b/flask_application_part/accuconf/proposals/templates/submit_proposal.html
@@ -50,7 +50,7 @@
                          <tr>
                          <th> Lead </th>
                          <th> Email </th>
-                         <th> Fist Name </th>
+                         <th> First Name </th>
                          <th> Last Name </th>
                          <th> Country </th>
                          <th> State </th>

--- a/flask_application_part/accuconf/proposals/templates/view_proposal.html
+++ b/flask_application_part/accuconf/proposals/templates/view_proposal.html
@@ -52,7 +52,7 @@
                         <tr>
                             <th> Lead </th>
                             <th> Email </th>
-                            <th> Fist Name </th>
+                            <th> First Name </th>
                             <th> Last Name </th>
                             <th> Country </th>
                             <th> State </th>


### PR DESCRIPTION
Fixes a label typo I noticed while submitting a proposal. Searching revealed additional similar mistakes.