### PR TITLE
CoC and the ACCU hashtag should show up in narrow mode as well

### DIFF
--- a/static_nikola_part/themes/accuconf/templates/base.tmpl
+++ b/static_nikola_part/themes/accuconf/templates/base.tmpl
@@ -55,6 +55,15 @@
     <!-- For single column rendering - In mobiles and tablets -->
     <div class="visible-xs-block">
         <div class="container-fluid">
+            <h4>
+              <a href="https://twitter.com/ACCUConf">@ACCUConf</a>
+              <a href="https://twitter.com/hashtag/ACCUConf">#ACCUConf</a>
+            </h4>
+            <hr/>
+            <h3>
+              <a href="/stories/coc_code_of_conduct.html">Code of Conduct</a>
+            </h3>
+
             <div class="accuconf-menu">
                 <a type="button" class="accuconf-toggle-link btn" data-toggle="collapse" href="#keydates">
                     <span class="accuconf-toggle glyphicon glyphicon-menu-hamburger"> Dates </span>


### PR DESCRIPTION
The CoC and ACCU hashtag were not added to the visible-xs block that
now has those two and the "Dates" block. This should fix issue #52 