### PR TITLE
Sponsors logo should be visible in narrow screens

### DIFF
--- a/static_nikola_part/themes/accuconf/templates/base.tmpl
+++ b/static_nikola_part/themes/accuconf/templates/base.tmpl
@@ -135,6 +135,9 @@
         <div class="row">
             {{ accuconf.organiser() }}
         </div>
+        <div class="row">
+          {{ accuconf.sponsors() }}
+        </div>
     </div>
 </div> <!--  End of div.row -->
 

--- a/static_nikola_part/themes/accuconf/templates/base.tmpl
+++ b/static_nikola_part/themes/accuconf/templates/base.tmpl
@@ -135,7 +135,7 @@
         <div class="row">
             {{ accuconf.organiser() }}
         </div>
-        <div class="row">
+        <div class="row visible-xs">
           {{ accuconf.sponsors() }}
         </div>
     </div>


### PR DESCRIPTION
Added the sponsors block and made it a visible-xs so that it shows up only on narrow screens since we already have it for normal/wide screens.