### PR TITLE
Added CORS support for the schedule-proposal api.

### DIFF
--- a/flask_application_part/accuconf/proposals/views.py
+++ b/flask_application_part/accuconf/proposals/views.py
@@ -4,6 +4,8 @@ from random import randint
 from flask import render_template, jsonify, redirect, url_for, session, request
 from flask import send_from_directory, g
 
+from flask_cors import CORS, cross_origin
+
 from accuconf import db
 from accuconf.models import MathPuzzle, User, ProposalPresenter, Proposal, Presenter, Score, Comment
 from accuconf.proposals.utils.proposals import SessionType
@@ -65,6 +67,7 @@ def proposal_to_json(proposal):
 
 
 @proposals.route("/api/scheduled_proposals", methods=['GET'])
+@cross_origin()
 def all_proposals():
     props = Proposal.query.filter(Proposal.day != None,
                                   Proposal.session != None).all()

--- a/flask_application_part/accuconf/proposals/views.py
+++ b/flask_application_part/accuconf/proposals/views.py
@@ -4,7 +4,7 @@ from random import randint
 from flask import render_template, jsonify, redirect, url_for, session, request
 from flask import send_from_directory, g
 
-from flask_cors import CORS, cross_origin
+from flask_cors import cross_origin
 
 from accuconf import db
 from accuconf.models import MathPuzzle, User, ProposalPresenter, Proposal, Presenter, Score, Comment

--- a/flask_application_part/pip_requirements.txt
+++ b/flask_application_part/pip_requirements.txt
@@ -2,6 +2,7 @@
 
 Flask
 Flask-Bootstrap
+flask-cors
 SQLAlchemy
 Flask_SQLAlchemy
 


### PR DESCRIPTION
Without this, we can't fetch the JSON data from a domain other than the JSON API's. While we may ultimately not need this, I think it's useful for now since we can develop the Elm app and the ACCU website independently. I'll be able to figure out some hosting solution (e.g. hosting the Elm app from Sixty North's servers) that we can use in at least the near term.