### PR TITLE
Presenter API

### DIFF
--- a/flask_application_part/accuconf/proposals/views.py
+++ b/flask_application_part/accuconf/proposals/views.py
@@ -47,7 +47,7 @@ def proposal_to_json(proposal):
         'session': proposal.session.value,
         'room': proposal.room.value,
         # 'track': proposal.track.value,
-        'presenters': [presenter.id
+        'presenters': [presenter.presenter.id
                        for presenter
                        in proposal.presenters]
     }

--- a/flask_application_part/accuconf/proposals/views.py
+++ b/flask_application_part/accuconf/proposals/views.py
@@ -63,7 +63,9 @@ def presenter_to_json(presenter):
         'id': presenter.id,
         'last_name': presenter.last_name,
         'first_name': presenter.first_name,
-        'bio': presenter.bio
+        'bio': presenter.bio,
+        'country': presenter.country,
+        'state': presenter.state
     }
 
 

--- a/flask_application_part/accuconf/proposals/views.py
+++ b/flask_application_part/accuconf/proposals/views.py
@@ -288,7 +288,7 @@ def show_proposals():
                     "title": proposal.title,
                     "abstract": proposal.text,
                     "session_type": proposal.session_type,
-                    "resenters": proposal.presenters,
+                    "presenters": proposal.presenters,
                 }
             }
             page["subpages"].append(subpage)

--- a/flask_application_part/accuconf/proposals/views.py
+++ b/flask_application_part/accuconf/proposals/views.py
@@ -38,14 +38,6 @@ def init_blueprint(context):
         proposals.admin.add_view(PresentersAdmin(Presenter, db.session))
 
 
-def proposal_presenter_to_json(presenter):
-    return {
-        'id': presenter.presenter.id,
-        'first_name': presenter.presenter.first_name,
-        'last_name': presenter.presenter.last_name
-    }
-
-
 def proposal_to_json(proposal):
     result = {
         'id': proposal.id,
@@ -55,7 +47,7 @@ def proposal_to_json(proposal):
         'session': proposal.session.value,
         'room': proposal.room.value,
         # 'track': proposal.track.value,
-        'presenters': [proposal_presenter_to_json(presenter)
+        'presenters': [presenter.id
                        for presenter
                        in proposal.presenters]
     }
@@ -66,6 +58,15 @@ def proposal_to_json(proposal):
     return result
 
 
+def presenter_to_json(presenter):
+    return {
+        'id': presenter.id,
+        'last_name': presenter.last_name,
+        'first_name': presenter.first_name,
+        'bio': presenter.bio
+    }
+
+
 @proposals.route("/api/scheduled_proposals", methods=['GET'])
 @cross_origin()
 def all_proposals():
@@ -73,6 +74,14 @@ def all_proposals():
                                   Proposal.session != None).all()
     prop_info = [proposal_to_json(prop) for prop in props]
     return jsonify(prop_info)
+
+
+@proposals.route("/api/presenters", methods=["GET"])
+@cross_origin()
+def all_presenters():
+    ps = Presenter.query.all()
+    json = [presenter_to_json(p) for p in ps]
+    return jsonify(json)
 
 
 @proposals.route("/")
@@ -277,7 +286,7 @@ def show_proposals():
                     "title": proposal.title,
                     "abstract": proposal.text,
                     "session_type": proposal.session_type,
-                    "presenters": proposal.presenters,
+                    "resenters": proposal.presenters,
                 }
             }
             page["subpages"].append(subpage)


### PR DESCRIPTION
This introduces an API for fetching presenter information from the server. This also changes the proposal API a bit.

This is a breaking API change for the current version of the schedule app. So we need to deploy this and a new version of the app in lock-step. I think the best way is to:

1. Release this change to the server on the `testconference` deployment
2. Put an updated version of the app on a test URL at sixty-north.com (this version is essentially ready)
3. Verify that things work as expected
4. Update the public deployments to use the new server and elm app at the same time.